### PR TITLE
Tables are straight! :godmode:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 Release notes for Board Games Results
 ====================================
 
-Planned in next version
+v0.0.3
 ------------------
 
 *   RAML docs
+*   [#11 Fix tables template](https://github.com/GorlifSense/Board-Games-Results/pull/11)
+
 
 v0.0.2 and before
 ------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "board-games-results",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Web app for storing results for 7 Wonders",
   "main": "app.js",
   "engines": {

--- a/views/tables.html
+++ b/views/tables.html
@@ -24,8 +24,8 @@
               </div>
            </div>
         </div>
-        {% endfor %}
-    </div>
+      </div>
+      {% endfor %}
   </div>
 
 {% endblock %}


### PR DESCRIPTION
With this fix layouts will become correct length on each line instead of cutting in size with each document

To review from @GorlifSense/frontend or @SolarLumenar as creator of template
