### PR TITLE
Remove default codecov bot as per advice from CodeCov Support team

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,5 @@
 codecov:
   branch: master
-  bot: codecov-io
 
 coverage:
   precision: 2


### PR DESCRIPTION
As per https://trello.com/c/KutVwuO3/46-discover-configuration-for-codecov-bot
